### PR TITLE
Fix package can not build in Flutter 3.29, change from v1 Android Plugin to v2

### DIFF
--- a/android/src/main/kotlin/app/web/groons/print_bluetooth_thermal/PrintBluetoothThermalPlugin.kt
+++ b/android/src/main/kotlin/app/web/groons/print_bluetooth_thermal/PrintBluetoothThermalPlugin.kt
@@ -26,8 +26,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch


### PR DESCRIPTION
// TODO: Check again the code

Flutter doctor result
```
$ flutter doctor -v
[✓] Flutter (Channel stable, 3.29.0, on Microsoft Windows [Version 10.0.26100.3194], locale
    id-ID) [240ms]
    • Flutter version 3.29.0 on channel stable at C:\flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision 35c388afb5 (3 days ago), 2025-02-10 12:48:41 -0800
    • Engine revision f73bfc4522
    • Dart version 3.7.0
    • DevTools version 2.42.2

[✓] Windows Version (11 Home Single Language 64-bit, 24H2, 2009) [1.761ms]

[✓] Android toolchain - develop for Android devices (Android SDK version 35.0.0) [1.359ms]
    • Android SDK at C:\Users\herma\AppData\Local\Android\Sdk
    • Platform android-35, build-tools 35.0.0
    • ANDROID_HOME = C:\Users\herma\AppData\Local\Android\Sdk
    • Java binary at: C:\java\jdk-17.0.2\bin\java
      This JDK is specified in your Flutter configuration.
      To change the current JDK, run: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version OpenJDK Runtime Environment (build 17.0.2+8-86)
    • All Android licenses accepted.

[✓] Chrome - develop for the web [19ms]
    • Chrome at C:\Program Files\Google\Chrome\Application\chrome.exe

[✗] Visual Studio - develop Windows apps [18ms]
    ✗ Visual Studio not installed; this is necessary to develop Windows apps.
      Download at https://visualstudio.microsoft.com/downloads/.
      Please install the "Desktop development with C++" workload, including all of its default
      components

[✓] Android Studio (version 2024.2) [16ms]
    • Android Studio at C:\Program Files\Android\Android Studio
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.5+-12932927-b750.29)

[✓] VS Code (version 1.97.2) [15ms]
    • VS Code at C:\Users\herma\AppData\Local\Programs\Microsoft VS Code
    • Flutter extension version 3.104.0

[✓] Connected device (4 available) [301ms]
    • SM A155F (mobile) • RR8X203HL2H • android-arm64  • Android 14 (API 34)
    • Windows (desktop) • windows     • windows-x64    • Microsoft Windows [Version
      10.0.26100.3194]
    • Chrome (web)      • chrome      • web-javascript • Google Chrome 133.0.6943.99
    • Edge (web)        • edge        • web-javascript • Microsoft Edge 133.0.3065.59

[✓] Network resources [425ms]
    • All expected network resources are available.

! Doctor found issues in 1 category.
```

Before deleting this code

```
Launching lib\main.dart on SM A155F in debug mode...
e: file:///C:/Users/<USERNAME>/AppData/Local/Pub/Cache/hosted/pub.dev/print_bluetooth_thermal-1.1.5/android/src/main/kotlin/app/web/groons/print_bluetooth_thermal/PrintBluetoothThermalPlugin.kt:30:48 Unresolved reference: Registrar

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':print_bluetooth_thermal:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 4s
Error: Gradle task assembleDebug failed with exit code 1

Exited (1).
```