### PR TITLE
Fix Apple Bluetooth connect readiness

### DIFF
--- a/ios/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
+++ b/ios/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
@@ -12,8 +12,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     var targetCharacteristic: CBCharacteristic? // Variable global para almacenar la característica objetivo
 
 
-    var flutterResult: FlutterResult? //para el resul de flutter
-    var bytes: [UInt8]? //variable para almacenar los bytes que llegan
     var stringprint = ""; //variable para almacenar los string que llegan
     var pendingConnectResult: FlutterResult?
     var pendingConnectTimeout: DispatchWorkItem?
@@ -175,9 +173,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
           result(false)
           return
         }
-        //let bytes = arguments
-        self.bytes = arguments.map { UInt8($0 & 0xFF) } //No se esta usando
-
         if let characteristic = targetCharacteristic {
             guard connectedPeripheral != nil else {
                 print("No hay periferico conectado")
@@ -185,7 +180,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 return
             }
             // Utiliza la variable characteristic desempaquetada aquí
-            //print("bytes count: \(self.bytes?.count)")
             let listbytes = arguments.map { UInt8($0 & 0xFF) }
             //self.connectedPeripheral?.writeValue(Data(listbytes), for: characteristic, type: .withoutResponse) //.withResponse, .withoutResponse
 
@@ -193,17 +187,18 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
             let data: Data = Data(listbytes) // Datos que deseas imprimir
             let chunkSize = 150 // Tamaño de cada fragmento en bytes
 
+            guard let writeType = preferredWriteType(for: characteristic) else {
+                print("La característica no admite escritura")
+                result(false)
+                return
+            }
+
             var offset = 0
             while offset < data.count {
                 let chunkRange = offset..<min(offset + chunkSize, data.count)
                 let chunkData = data.subdata(in: chunkRange)
                 //print("chunkData count: \(chunkData.count)")
                 // Envía el fragmento para imprimir utilizando la característica deseada
-
-                var writeType = CBCharacteristicWriteType.withoutResponse;
-                if characteristic.properties.contains(.write) {
-                   writeType = CBCharacteristicWriteType.withResponse;
-                }
 
                  self.connectedPeripheral?.writeValue(chunkData, for: characteristic, type: writeType)
 
@@ -257,9 +252,10 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                     // Envío de los datos
                     let datasize = Data(sizeBytes[size])
 
-                    var writeType = CBCharacteristicWriteType.withoutResponse;
-                    if characteristic.properties.contains(.write) {
-                        writeType = CBCharacteristicWriteType.withResponse;
+                    guard let writeType = preferredWriteType(for: characteristic) else {
+                        print("La característica no admite escritura")
+                        result(false)
+                        return
                     }
 
                     connectedPeripheral?.writeValue(datasize, for: characteristic, type: writeType)
@@ -301,6 +297,16 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         pendingConnectResult = nil
         pendingConnectPeripheral = nil
         result(success)
+    }
+
+    private func preferredWriteType(for characteristic: CBCharacteristic) -> CBCharacteristicWriteType? {
+        if characteristic.properties.contains(.write) {
+            return .withResponse
+        }
+        if characteristic.properties.contains(.writeWithoutResponse) {
+            return .withoutResponse
+        }
+        return nil
     }
 
 
@@ -385,6 +391,11 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 //print("characteristics found: \(characteristic.uuid)")
 
                 if allowedCharacteristics.contains(characteristic.uuid) {
+                    guard preferredWriteType(for: characteristic) != nil else {
+                        print("characteristics found: \(characteristic.uuid) La característica no admite escritura")
+                        continue
+                    }
+
                     targetCharacteristic = characteristic // Guarda la característica objetivo en la variable global
                     print("Target characteristic found: \(characteristic.uuid)")
 
@@ -400,7 +411,7 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 }
 
                 if targetCharacteristic == nil && targetService?.uuid == service.uuid {
-                    if characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) {
+                    if preferredWriteType(for: characteristic) != nil {
                         targetCharacteristic = characteristic
                         print("Using fallback writable characteristic: \(characteristic.uuid)")
                         completePendingConnect(true)

--- a/ios/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
+++ b/ios/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
@@ -15,6 +15,21 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     var flutterResult: FlutterResult? //para el resul de flutter
     var bytes: [UInt8]? //variable para almacenar los bytes que llegan
     var stringprint = ""; //variable para almacenar los string que llegan
+    var pendingConnectResult: FlutterResult?
+    var pendingConnectTimeout: DispatchWorkItem?
+    var pendingConnectPeripheral: CBPeripheral?
+
+    let allowedServices = [
+        CBUUID(string: "00001101-0000-1000-8000-00805F9B34FB"),
+        CBUUID(string: "49535343-FE7D-4AE5-8FA9-9FAFD205E455"),
+        CBUUID(string: "A76EB9E0-F3AC-4990-84CF-3A94D2426B2B")
+    ]
+
+    let allowedCharacteristics = [
+        CBUUID(string: "00001101-0000-1000-8000-00805F9B34FB"),
+        CBUUID(string: "49535343-8841-43F4-A8D4-ECBE34729BB3"),
+        CBUUID(string: "A76EB9E2-F3AC-4990-84CF-3A94D2426B2B")
+    ]
 
     // En el método init, inicializa el gestor central con un delegado
     //para solicitar el permiso del bluetooth
@@ -35,8 +50,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         self.centralManager = CBCentralManager(delegate: self, queue: nil)
     }
 
-    //para iniciar la variable result
-    self.flutterResult = result
     //result("iOS " + UIDevice.current.systemVersion)
     //let argumento = call.arguments as! String //leer el argumento recibido
     if call.method == "getPlatformVersion" { // Verifica si se está llamando el método "getPlatformVersion"
@@ -104,37 +117,50 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
             result(self.discoveredDevices)
         }
 
-    } 
+    }
     else if call.method == "connect"{
-        let macAddress = call.arguments as! String 
+        guard pendingConnectResult == nil else {
+          result(false)
+          return
+        }
+        guard let macAddress = call.arguments as? String,
+              let uuid = UUID(uuidString: macAddress) else {
+          result(false)
+          return
+        }
         // Busca el dispositivo con la dirección MAC dada
-        let peripherals = centralManager?.retrievePeripherals(withIdentifiers: [UUID(uuidString: macAddress)!])
+        let peripherals = centralManager?.retrievePeripherals(withIdentifiers: [uuid])
         guard let peripheral = peripherals?.first else {
           //print("No se encontró ningún dispositivo con la dirección MAC \(macAddress)")
           result(false)
           return
         }
 
-        // Intenta conectar con el dispositivo
-        centralManager?.connect(peripheral, options: nil)
-
-        // Verifica si la conexión fue exitosa después de un tiempo de espera
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-            if peripheral.state == .connected {
-                //print("Conexión exitosa con el dispositivo \(peripheral.name ?? "Desconocido")")
-                self.connectedPeripheral = peripheral
-
-                self.connectedPeripheral.delegate = self
-                // Discover services of the connected peripheral
-                //se ejecuta los servicios descubiertos en primer peripheral
-                self.connectedPeripheral?.discoverServices(nil)
-                result(true)
-            } else {
-                //print("La conexión con el dispositivo \(peripheral.name ?? "Desconocido") falló")
-                result(false)
-            }
+        if peripheral.state == .connected && targetCharacteristic != nil {
+            connectedPeripheral = peripheral
+            result(true)
+            return
         }
-  
+
+        targetService = nil
+        targetCharacteristic = nil
+        connectedPeripheral = peripheral
+        connectedPeripheral.delegate = self
+        pendingConnectResult = result
+        pendingConnectPeripheral = peripheral
+
+        let timeout = DispatchWorkItem { [weak self] in
+            self?.completePendingConnect(false)
+        }
+        pendingConnectTimeout = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timeout)
+
+        if peripheral.state == .connected {
+            peripheral.discoverServices(nil)
+        } else {
+            centralManager?.connect(peripheral, options: nil)
+        }
+
     }else if call.method == "connectionstatus"{
       if connectedPeripheral?.state == CBPeripheralState.connected {
           //print("El dispositivo periférico está conectado.")
@@ -146,18 +172,21 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     }else if call.method == "writebytes"{
         guard let arguments = call.arguments as? [Int] else {
           // Manejar el caso en que los argumentos no son del tipo esperado
+          result(false)
           return
         }
         //let bytes = arguments
-        self.bytes = arguments.map { UInt8($0) } //No se esta usando
+        self.bytes = arguments.map { UInt8($0 & 0xFF) } //No se esta usando
 
         if let characteristic = targetCharacteristic {
-            // Utiliza la variable characteristic desempaquetada aquí
-            //print("bytes count: \(self.bytes?.count)")
-            guard let listbytes = call.arguments as? [UInt8] else {
-                // Manejar el caso en que los argumentos no son del tipo esperado
+            guard connectedPeripheral != nil else {
+                print("No hay periferico conectado")
+                result(false)
                 return
             }
+            // Utiliza la variable characteristic desempaquetada aquí
+            //print("bytes count: \(self.bytes?.count)")
+            let listbytes = arguments.map { UInt8($0 & 0xFF) }
             //self.connectedPeripheral?.writeValue(Data(listbytes), for: characteristic, type: .withoutResponse) //.withResponse, .withoutResponse
 
             //Imprimir bloques de 150 bytes en la impresora para que no se sature
@@ -177,20 +206,29 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 }
 
                  self.connectedPeripheral?.writeValue(chunkData, for: characteristic, type: writeType)
-                   
+
                 offset += chunkSize
             }
-            //la respuesta va en peripheral
-            //self.flutterResult?(true)
+            result(true)
         } else {
             print("No hay caracteristica para imprimir")
             result(false)
         }
 
       } else if call.method == "printstring"{
-        self.stringprint = call.arguments as! String
+        guard let stringArg = call.arguments as? String else {
+            result(false)
+            return
+        }
+        self.stringprint = stringArg
         //print("llego a printstring\(self.stringprint)")
         if let characteristic = targetCharacteristic {
+            guard connectedPeripheral != nil else {
+                print("No hay periferico conectado")
+                result(false)
+                return
+            }
+
             if self.stringprint.count > 0 {
                     //ver el tamaño del texto
                     var size = 0
@@ -234,24 +272,38 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                     connectedPeripheral?.writeValue(datareset, for: characteristic, type: writeType)
                     stringprint = ""
 
-                    //la respuesta va en peripheral si es .withResponse
-                    //self.flutterResult?(true)
+                    result(true)
+                } else {
+                    result(false)
                 }
         } else {
             print("No hay caracteristica para imprimir")
             result(false)
         }
         } else if call.method == "disconnect"{
-        centralManager?.cancelPeripheralConnection(connectedPeripheral)
+        if connectedPeripheral != nil {
+            centralManager?.cancelPeripheralConnection(connectedPeripheral)
+        }
         targetCharacteristic = nil
-        //la respuesta va en centralManager segunda funcion
-        //result(true)
+        result(true)
       } else {
         result(FlutterMethodNotImplemented) // Si se llama otro método que no está implementado, se devuelve un error
       }
   }
 
-  
+    private func completePendingConnect(_ success: Bool) {
+        guard let result = pendingConnectResult else {
+            return
+        }
+
+        pendingConnectTimeout?.cancel()
+        pendingConnectTimeout = nil
+        pendingConnectResult = nil
+        pendingConnectPeripheral = nil
+        result(success)
+    }
+
+
     public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
         //print("Discovered \(peripheral.name ?? "Unknown") at \(RSSI) dBm")
         if let deviceName = peripheral.name {
@@ -264,14 +316,30 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         }
     }
 
+    public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        connectedPeripheral = peripheral
+        connectedPeripheral.delegate = self
+        targetService = nil
+        targetCharacteristic = nil
+        peripheral.discoverServices(nil)
+    }
+
+    public func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        if pendingConnectPeripheral?.identifier == peripheral.identifier {
+            completePendingConnect(false)
+        }
+    }
+
     //funcion para verificar si desconecto el dispositivo
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        if error != nil {
-            //print("Error al desconectar del dispositivo: \(error!.localizedDescription)")
-            self.flutterResult?(false)
-        } else {
-        //print("Se ha desconectado del dispositivo con éxito")
-         self.flutterResult?(true)
+        if pendingConnectPeripheral?.identifier == peripheral.identifier {
+            completePendingConnect(false)
+        }
+
+        if connectedPeripheral?.identifier == peripheral.identifier {
+            connectedPeripheral = nil
+            targetService = nil
+            targetCharacteristic = nil
         }
     }
 
@@ -279,23 +347,18 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
            if let error = error {
                print("Error discovering services: \(error.localizedDescription)")
+               if pendingConnectPeripheral?.identifier == peripheral.identifier {
+                   completePendingConnect(false)
+               }
                return
            }
 
            if let services = peripheral.services {
                for service in services {
                    print("Service discovered: \(service.uuid)")
-                   let allowedServices = [
-                        CBUUID(string: "00001101-0000-1000-8000-00805F9B34FB"),
-                        CBUUID(string: "49535343-FE7D-4AE5-8FA9-9FAFD205E455"),
-                        CBUUID(string: "A76EB9E0-F3AC-4990-84CF-3A94D2426B2B")
-                   ]
 
                    if allowedServices.contains(service.uuid) {
-                       print("Service found: \(service.uuid)") 
-                       // Por ejemplo, puedes descubrir las características del servicio
-                       peripheral.discoverCharacteristics(nil, for: service)
-
+                       print("Service found: \(service.uuid)")
                        // También puedes almacenar el servicio en una variable para futuras referencias
                        // targetService = service
                        self.targetService = service;
@@ -311,23 +374,20 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     public func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         if let error = error {
             print("Error discovering characteristics: \(error.localizedDescription)")
+            if pendingConnectPeripheral?.identifier == peripheral.identifier {
+                completePendingConnect(false)
+            }
             return
         }
 
         if let discoveredCharacteristics = service.characteristics {
             for characteristic in discoveredCharacteristics {
                 //print("characteristics found: \(characteristic.uuid)")
-            
-                let allowedCharacteristics = [
-                    CBUUID(string: "00001101-0000-1000-8000-00805F9B34FB"), 
-                    CBUUID(string: "49535343-8841-43F4-A8D4-ECBE34729BB3"), 
-                    CBUUID(string: "A76EB9E2-F3AC-4990-84CF-3A94D2426B2B")
-                ]
 
                 if allowedCharacteristics.contains(characteristic.uuid) {
                     targetCharacteristic = characteristic // Guarda la característica objetivo en la variable global
                     print("Target characteristic found: \(characteristic.uuid)")
-                 
+
                     if characteristic.properties.contains(.write) {
                         // La característica admite escritura
                         print("characteristics found: \(characteristic.uuid) La característica admite escritura")
@@ -335,7 +395,16 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                         // La característica no admite escritura
                         print("characteristics found: \(characteristic.uuid) La característica no admite escritura")
                     }
-                    break
+                    completePendingConnect(true)
+                    return
+                }
+
+                if targetCharacteristic == nil && targetService?.uuid == service.uuid {
+                    if characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) {
+                        targetCharacteristic = characteristic
+                        print("Using fallback writable characteristic: \(characteristic.uuid)")
+                        completePendingConnect(true)
+                    }
                 }
             }
         }
@@ -345,14 +414,12 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     public func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         if let error = error {
            print("Error al escribir en la característica: \(error.localizedDescription)")
-            self.flutterResult?(false)
            return
         }
-         self.flutterResult?(true)
         print("Escritura exitosa en la característica: \(characteristic.uuid)")
         // Aquí puedes realizar operaciones adicionales con la respuesta de la escritura
     }
-    
+
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         switch central.state {
             case .poweredOn:

--- a/macos/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
+++ b/macos/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
@@ -10,8 +10,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     var targetService: CBService?
     var targetCharacteristic: CBCharacteristic?
 
-    var flutterResult: FlutterResult?
-    var bytes: [UInt8]?
     var stringprint = ""
     
     // Pending callbacks for Bluetooth state queries
@@ -162,6 +160,12 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
             let bytesData = arguments.map { UInt8($0 & 0xFF) }
             let data = Data(bytesData)
             
+            guard let writeType = preferredWriteType(for: characteristic) else {
+                print("writebytes: Characteristic does not support write")
+                result(false)
+                return
+            }
+
             // Send in chunks of 150 bytes to avoid overwhelming the printer
             let chunkSize = 150
             var offset = 0
@@ -170,7 +174,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 let chunkRange = offset..<min(offset + chunkSize, data.count)
                 let chunkData = data.subdata(in: chunkRange)
                 
-                let writeType: CBCharacteristicWriteType = characteristic.properties.contains(.write) ? .withResponse : .withoutResponse
                 connectedPeripheral.writeValue(chunkData, for: characteristic, type: writeType)
                 
                 offset += chunkSize
@@ -222,7 +225,11 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
             ]
             let resetBytes: [UInt8] = [0x1b, 0x40]
             
-            let writeType: CBCharacteristicWriteType = characteristic.properties.contains(.write) ? .withResponse : .withoutResponse
+            guard let writeType = preferredWriteType(for: characteristic) else {
+                print("printstring: Characteristic does not support write")
+                result(false)
+                return
+            }
             
             // Send size command
             let dataSize = Data(sizeBytes[size])
@@ -254,6 +261,16 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         pendingConnectResult = nil
         pendingConnectPeripheral = nil
         result(success)
+    }
+
+    private func preferredWriteType(for characteristic: CBCharacteristic) -> CBCharacteristicWriteType? {
+        if characteristic.properties.contains(.write) {
+            return .withResponse
+        }
+        if characteristic.properties.contains(.writeWithoutResponse) {
+            return .withoutResponse
+        }
+        return nil
     }
 
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
@@ -352,6 +369,9 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     public func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         if let error = error {
             print("Error discovering characteristics: \(error.localizedDescription)")
+            if pendingConnectPeripheral?.identifier == peripheral.identifier {
+                completePendingConnect(false)
+            }
             return
         }
         
@@ -361,6 +381,11 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 
                 // Check if this is a known printer characteristic
                 if allowedCharacteristics.contains(characteristic.uuid) {
+                    guard preferredWriteType(for: characteristic) != nil else {
+                        print("Known printer characteristic is not writable: \(characteristic.uuid)")
+                        continue
+                    }
+
                     targetCharacteristic = characteristic
                     print("Target printer characteristic found: \(characteristic.uuid)")
                     
@@ -376,7 +401,7 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 
                 // Fallback: if no specific characteristic found, use any writable one
                 if targetCharacteristic == nil && targetService?.uuid == service.uuid {
-                    if characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) {
+                    if preferredWriteType(for: characteristic) != nil {
                         targetCharacteristic = characteristic
                         print("Using fallback writable characteristic: \(characteristic.uuid)")
                         completePendingConnect(true)

--- a/macos/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
+++ b/macos/print_bluetooth_thermal/Sources/print_bluetooth_thermal/PrintBluetoothThermalPlugin.swift
@@ -17,6 +17,9 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
     // Pending callbacks for Bluetooth state queries
     var pendingBluetoothEnabledResult: FlutterResult?
     var pendingPermissionResult: FlutterResult?
+    var pendingConnectResult: FlutterResult?
+    var pendingConnectTimeout: DispatchWorkItem?
+    var pendingConnectPeripheral: CBPeripheral?
     
     // Allowed service and characteristic UUIDs for thermal printers
     let allowedServices = [
@@ -46,8 +49,6 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         if self.centralManager == nil {
             self.centralManager = CBCentralManager(delegate: self, queue: nil)
         }
-
-        self.flutterResult = result
 
         if call.method == "getPlatformVersion" {
             let macOSVersion = ProcessInfo.processInfo.operatingSystemVersion
@@ -90,6 +91,10 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 result(self.discoveredDevices)
             }
         } else if call.method == "connect" {
+            guard pendingConnectResult == nil else {
+                result(false)
+                return
+            }
             guard let macAddress = call.arguments as? String,
                   let uuid = UUID(uuidString: macAddress) else {
                 result(false)
@@ -100,16 +105,30 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                 result(false)
                 return
             }
-            centralManager?.connect(peripheral, options: nil)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                if peripheral.state == .connected {
-                    self.connectedPeripheral = peripheral
-                    self.connectedPeripheral.delegate = self
-                    self.connectedPeripheral.discoverServices(nil)
-                    result(true)
-                } else {
-                    result(false)
-                }
+
+            if peripheral.state == .connected && targetCharacteristic != nil {
+                connectedPeripheral = peripheral
+                result(true)
+                return
+            }
+
+            targetService = nil
+            targetCharacteristic = nil
+            connectedPeripheral = peripheral
+            connectedPeripheral.delegate = self
+            pendingConnectResult = result
+            pendingConnectPeripheral = peripheral
+
+            let timeout = DispatchWorkItem { [weak self] in
+                self?.completePendingConnect(false)
+            }
+            pendingConnectTimeout = timeout
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timeout)
+
+            if peripheral.state == .connected {
+                peripheral.discoverServices(nil)
+            } else {
+                centralManager?.connect(peripheral, options: nil)
             }
         } else if call.method == "connectionstatus" {
             result(connectedPeripheral?.state == .connected)
@@ -225,6 +244,18 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         }
     }
 
+    private func completePendingConnect(_ success: Bool) {
+        guard let result = pendingConnectResult else {
+            return
+        }
+
+        pendingConnectTimeout?.cancel()
+        pendingConnectTimeout = nil
+        pendingConnectResult = nil
+        pendingConnectPeripheral = nil
+        result(success)
+    }
+
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         // Handle pending bluetoothenabled request
         if let pendingResult = self.pendingBluetoothEnabledResult {
@@ -267,13 +298,38 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
         }
     }
 
+    public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        connectedPeripheral = peripheral
+        connectedPeripheral.delegate = self
+        targetService = nil
+        targetCharacteristic = nil
+        peripheral.discoverServices(nil)
+    }
+
+    public func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        if pendingConnectPeripheral?.identifier == peripheral.identifier {
+            completePendingConnect(false)
+        }
+    }
+
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        flutterResult?(error == nil)
+        if pendingConnectPeripheral?.identifier == peripheral.identifier {
+            completePendingConnect(false)
+        }
+
+        if connectedPeripheral?.identifier == peripheral.identifier {
+            connectedPeripheral = nil
+            targetService = nil
+            targetCharacteristic = nil
+        }
     }
 
     public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         if let error = error {
             print("Error discovering services: \(error.localizedDescription)")
+            if pendingConnectPeripheral?.identifier == peripheral.identifier {
+                completePendingConnect(false)
+            }
             return
         }
         
@@ -314,14 +370,16 @@ public class PrintBluetoothThermalPlugin: NSObject, CBCentralManagerDelegate, CB
                     if characteristic.properties.contains(.writeWithoutResponse) {
                         print("Characteristic supports write without response")
                     }
+                    completePendingConnect(true)
                     return // Found the right characteristic, stop searching
                 }
                 
                 // Fallback: if no specific characteristic found, use any writable one
-                if targetCharacteristic == nil {
+                if targetCharacteristic == nil && targetService?.uuid == service.uuid {
                     if characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) {
                         targetCharacteristic = characteristic
                         print("Using fallback writable characteristic: \(characteristic.uuid)")
+                        completePendingConnect(true)
                     }
                 }
             }


### PR DESCRIPTION
Summary:
- Wait for the writable printer characteristic before reporting a successful connection on macOS and iOS.
- Avoid duplicate Flutter method responses for write and disconnect calls.
- Only select characteristics that support write or writeWithoutResponse.

Why:
CoreBluetooth connects to the peripheral before service and characteristic discovery has finished. If connect returns true too early, a writeBytes call can run before the printer characteristic is available.

Validation:
- Ran flutter analyze --no-pub after flutter pub get. Only existing example warnings remain.
- Confirmed macOS debug build passes.
- Confirmed iOS debug build passes with --no-codesign.